### PR TITLE
fix: multiple reports for the same function call

### DIFF
--- a/asasalint_test.go
+++ b/asasalint_test.go
@@ -7,6 +7,8 @@ import (
 	"go/token"
 	"go/types"
 	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 const filename = "<src>"
@@ -88,4 +90,8 @@ func TestNewAnalyzer(t *testing.T) {
 		NoBuiltinExclude: true,
 		IgnoreInTest:     true,
 	})
+}
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), NewAnalyzer(LinterSetting{}), "simple")
 }

--- a/testdata/src/simple/main.go
+++ b/testdata/src/simple/main.go
@@ -2,12 +2,12 @@ package main
 
 func main() {
 	var a = []any{1, 2, 3}
-	getArgsLength(a)
+	getArgsLength(a) // want `pass \[\]any as any to func getArgsLength func\(args \.\.\.any\) int`
 	getArgsLength(a...)
 	getArgsLength(1, 2, 3)
-	getArgsLength([]any{1, 2, 3})
-	getArgsLength(append([]any{1, 2, 3}, 4, 5, 6))
+	getArgsLength([]any{1, 2, 3})                  // want `pass \[\]any as any to func getArgsLength func\(args \.\.\.any\) int`
+	getArgsLength(append([]any{1, 2, 3}, 4, 5, 6)) // want `pass \[\]any as any to func getArgsLength func\(args \.\.\.any\) int`
 
 	getOneOrMore(a)
-	getOneOrMore(1, a)
+	getOneOrMore(1, a) // want `pass \[\]any as any to func getOneOrMore func\(arg any, others \.\.\.any\) int`
 }


### PR DESCRIPTION
Uses `Preorder` instead of `Nodes` to avoid multiple reports on the same function call.