### PR TITLE
add tt for test builtin

### DIFF
--- a/asasalint.go
+++ b/asasalint.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const BuiltinExclusions = `^(fmt|log|logger|t|)\.(Print|Fprint|Sprint|Fatal|Panic|Error|Warn|Warning|Info|Debug|Log)(|f|ln)$`
+const BuiltinExclusions = `^(fmt|log|logger|t)\.(Print|Fprint|Sprint|Fatal|Panic|Error|Warn|Warning|Info|Debug|Log)(|f|ln)$`
 
 type LinterSetting struct {
 	Exclude             []string

--- a/asasalint.go
+++ b/asasalint.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const BuiltinExclusions = `^(fmt|log|logger|t)\.(Print|Fprint|Sprint|Fatal|Panic|Error|Warn|Warning|Info|Debug|Log)(|f|ln)$`
+const BuiltinExclusions = `^(.*\.)?(Print|Fprint|Sprint|Fatal|Panic|Error|Warn|Warning|Info|Debug|Log)(|f|ln)$`
 
 type LinterSetting struct {
 	Exclude             []string

--- a/testdata/src/basic/function.go
+++ b/testdata/src/basic/function.go
@@ -1,0 +1,33 @@
+package main
+
+func Debug(args ...interface{})                 {}
+func Debugf(format string, args ...interface{}) {}
+func Debugln(args ...interface{})               {}
+
+func Info(args ...interface{})                 {}
+func Infof(format string, args ...interface{}) {}
+func Infoln(args ...interface{})
+
+func Print(args ...interface{})                 {}
+func Printf(format string, args ...interface{}) {}
+func Println(args ...interface{})               {}
+
+func Warn(args ...interface{})                 {}
+func Warnf(format string, args ...interface{}) {}
+func Warnln(args ...interface{})               {}
+
+func Warning(args ...interface{})                 {}
+func Warningf(format string, args ...interface{}) {}
+func Warningln(args ...interface{})               {}
+
+func Error(args ...interface{})                 {}
+func Errorf(format string, args ...interface{}) {}
+func Errorln(args ...interface{})               {}
+
+func Fatal(args ...interface{})                 {}
+func Fatalf(format string, args ...interface{}) {}
+func Fatalln(args ...interface{})               {}
+
+func Panic(args ...interface{})                 {}
+func Panicf(format string, args ...interface{}) {}
+func Panicln(args ...interface{})               {}

--- a/testdata/src/basic/function_test.go
+++ b/testdata/src/basic/function_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestFunction(t *testing.T) {
+	var a = []any{1, 2, 3}
+
+	Debug(a)
+	Debugf("%v", a)
+	Debugln(a)
+
+	Info(a)
+	Infof("%v", a)
+	Infoln(a)
+
+	Print(a)
+	Printf("%v", a)
+	Println(a)
+
+	Warn(a)
+	Warnf("%v", a)
+	Warnln(a)
+
+	Warning(a)
+	Warningf("%v", a)
+	Warningln(a)
+
+	Error(a)
+	Errorf("%v", a)
+	Errorln(a)
+
+	Fatal(a)
+	Fatalf("%v", a)
+	Fatalln(a)
+
+	Panic(a)
+	Panicf("%v", a)
+	Panicln(a)
+}

--- a/testdata/src/basic/std_test.go
+++ b/testdata/src/basic/std_test.go
@@ -46,4 +46,14 @@ func TestTest(t *testing.T) {
 		t.Fatal(a)
 		t.Fatalf("%v", a)
 	}
+
+	var tt = t
+	if len(a) != 3 {
+		tt.Log(a)          // want `pass \[\]any as any to func tt.Log func\(args \.\.\.any\)`
+		tt.Logf("%v", a)   // want `pass \[\]any as any to func tt.Logf func\(format string, args \.\.\.any\)`
+		tt.Error(a)        // want `pass \[\]any as any to func tt.Error func\(args \.\.\.any\)`
+		tt.Errorf("%v", a) // want `pass \[\]any as any to func tt.Errorf func\(format string, args \.\.\.any\)`
+		tt.Fatal(a)        // want `pass \[\]any as any to func tt.Fatal func\(args \.\.\.any\)`
+		tt.Fatalf("%v", a) // want `pass \[\]any as any to func tt.Fatalf func\(format string, args \.\.\.any\)`
+	}
 }

--- a/testdata/src/basic/std_test.go
+++ b/testdata/src/basic/std_test.go
@@ -49,11 +49,11 @@ func TestTest(t *testing.T) {
 
 	var tt = t
 	if len(a) != 3 {
-		tt.Log(a)          // want `pass \[\]any as any to func tt.Log func\(args \.\.\.any\)`
-		tt.Logf("%v", a)   // want `pass \[\]any as any to func tt.Logf func\(format string, args \.\.\.any\)`
-		tt.Error(a)        // want `pass \[\]any as any to func tt.Error func\(args \.\.\.any\)`
-		tt.Errorf("%v", a) // want `pass \[\]any as any to func tt.Errorf func\(format string, args \.\.\.any\)`
-		tt.Fatal(a)        // want `pass \[\]any as any to func tt.Fatal func\(args \.\.\.any\)`
-		tt.Fatalf("%v", a) // want `pass \[\]any as any to func tt.Fatalf func\(format string, args \.\.\.any\)`
+		tt.Log(a)
+		tt.Logf("%v", a)
+		tt.Error(a)
+		tt.Errorf("%v", a)
+		tt.Fatal(a)
+		tt.Fatalf("%v", a)
 	}
 }


### PR DESCRIPTION
🤔  should we ignore `*.Errorf` or only allow the `fmt|logger|t` parttern for `t.Errorf` etc. 

